### PR TITLE
Add a note to clarify limitations of arithmetic opcodes

### DIFF
--- a/protocol/blockchain/script.md
+++ b/protocol/blockchain/script.md
@@ -125,6 +125,8 @@ Op codes marked with **(do not use)** are disallowed and will make a transaction
 
 ### Arithmetic
 
+Numeric opcodes (OP_1ADD, etc) are restricted to operating on 4-byte integers. The semantics are subtle, though: operands must be in the range [-2^31 +1...2^31 -1], but results may overflow (and are valid as long as they are not used in a subsequent numeric operation).
+
 |Word                 |Value  |Hex |Input         |Output           | Description                                          |
 |---------------------|-------|----|--------------|-----------------|------------------------------------------------------|
 |OP_1ADD              | 139   |0x8b|in            |out              | 	1 is added to the input.                            |


### PR DESCRIPTION
Copied from: https://gitlab.com/bitcoin-cash-node/bitcoin-cash-node/-/blob/master/src/script/script.h#L213